### PR TITLE
Fix LCD font fallback, error-handler crash, and sensor-frame orientation on Linux

### DIFF
--- a/openkraken/backend/device.py
+++ b/openkraken/backend/device.py
@@ -678,7 +678,15 @@ class KrakenDevice:
                 return self._set_screen("static", str(image_path))
 
             try:
-                data = dev._prepare_static_file(str(image_path), getattr(dev, "orientation", 0))
+                # Pre-rotate with our own authoritative orientation (degrees ->
+                # raw 0..3), NOT the liquidctl driver's ``dev.orientation``.  The
+                # latter is only refreshed as a side effect of ``set_screen`` and
+                # is left stale after an orientation change (it holds the value
+                # read *before* the write), and can even be garbage on an HID
+                # reply de-sync -- both of which rotated streamed sensor frames to
+                # the wrong / seemingly "random" direction and made orientation
+                # appear to change across restarts.
+                data = dev._prepare_static_file(str(image_path), self.lcd_orientation // 90)
             except _RECOVERABLE_SCREEN_ERRORS as exc:
                 logger.warning("sensor frame: image prepare failed (%s)", exc)
                 return False

--- a/openkraken/backend/lcd_render.py
+++ b/openkraken/backend/lcd_render.py
@@ -30,6 +30,9 @@ from __future__ import annotations
 
 import logging
 import math
+import os
+import shutil
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -94,9 +97,13 @@ _LIQUID_MAX = 60.0
 
 _PLACEHOLDER = "--"
 
-# Font candidate chain (per spec).
+# Bold sans-serif font candidates, tried in order. Absolute distro paths first
+# (fast, and preserves the intended DejaVu look), then a bare name PIL can find.
+# If none resolve, _font() falls back to fontconfig (see _fontconfig_bold_sans).
 _FONT_CANDIDATES = (
-    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",    # Debian/Ubuntu
+    "/usr/share/fonts/dejavu-sans-fonts/DejaVuSans-Bold.ttf",  # Fedora
+    "/usr/share/fonts/TTF/DejaVuSans-Bold.ttf",                # Arch
     "DejaVuSans-Bold.ttf",
 )
 
@@ -133,12 +140,47 @@ class LcdData:
 
 _FONT_CACHE: dict[int, ImageFont.FreeTypeFont | ImageFont.ImageFont] = {}
 
+# Resolved bold sans-serif path from fontconfig (see _fontconfig_bold_sans).
+# `_UNRESOLVED` distinguishes "not looked up yet" from "looked up, found nothing".
+_UNRESOLVED = object()
+_FC_FONT_FILE: str | None | object = _UNRESOLVED
+
+
+def _fontconfig_bold_sans() -> str | None:
+    """Return a bold sans-serif TTF path via ``fc-match`` (cached), or None.
+
+    Used when the hardcoded :data:`_FONT_CANDIDATES` are absent, so distros that
+    don't ship DejaVu at the expected path (e.g. Fedora) still get a real
+    TrueType font instead of PIL's low-res default bitmap.
+    """
+    global _FC_FONT_FILE
+    if _FC_FONT_FILE is not _UNRESOLVED:
+        return _FC_FONT_FILE  # type: ignore[return-value]
+
+    _FC_FONT_FILE = None
+    fc_match = shutil.which("fc-match")
+    if fc_match is not None:
+        for query in ("DejaVu Sans:style=Bold", "sans-serif:style=Bold"):
+            try:
+                out = subprocess.run(
+                    [fc_match, "-f", "%{file}", query],
+                    capture_output=True, text=True, timeout=5, check=False,
+                ).stdout.strip()
+            except (OSError, subprocess.SubprocessError):
+                continue
+            if out and os.path.isfile(out):
+                _LOGGER.info("LCD font resolved via fontconfig: %s", out)
+                _FC_FONT_FILE = out
+                break
+    return _FC_FONT_FILE  # type: ignore[return-value]
+
 
 def _font(size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
     """Return a bold font of *size* px, cached at module level by size.
 
-    Tries the DejaVuSans-Bold candidate chain, then falls back to the bundled
-    PIL default font (which still honours ``size`` on Pillow >= 10).
+    Tries the :data:`_FONT_CANDIDATES` chain, then fontconfig (``fc-match``) for
+    a bold sans-serif, and only as a last resort the bundled PIL default font
+    (which still honours ``size`` on Pillow >= 10).
     """
     cached = _FONT_CACHE.get(size)
     if cached is not None:
@@ -153,8 +195,16 @@ def _font(size: int) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
             continue
 
     if font is None:
+        path = _fontconfig_bold_sans()
+        if path is not None:
+            try:
+                font = ImageFont.truetype(path, size)
+            except OSError:
+                font = None
+
+    if font is None:
         _LOGGER.warning(
-            "DejaVuSans-Bold not found; falling back to PIL default font at %d px",
+            "no bold TrueType font found; using PIL default font at %d px",
             size,
         )
         try:

--- a/openkraken/gui/main_window.py
+++ b/openkraken/gui/main_window.py
@@ -427,11 +427,17 @@ class MainWindow(QMainWindow):
         bar.setStyleSheet(f"color: {theme.COLORS['crit']};")
         bar.showMessage(f"Error: {message}", _ERROR_MSG_MS)
         # Clear the red styling once the message expires.  Connect with a unique
-        # connection so repeated errors do not stack duplicate slots.
-        bar.messageChanged.connect(
-            self._on_status_message_changed,
-            Qt.ConnectionType.UniqueConnection,
-        )
+        # connection so repeated errors do not stack duplicate slots.  In PyQt6,
+        # re-connecting an already-connected unique slot raises TypeError (unlike
+        # C++ Qt's silent no-op); that "already armed" state is exactly what we
+        # want, so ignore it — otherwise back-to-back errors crash the GUI.
+        try:
+            bar.messageChanged.connect(
+                self._on_status_message_changed,
+                Qt.ConnectionType.UniqueConnection,
+            )
+        except TypeError:
+            pass
 
     def _on_status_message_changed(self, text: str) -> None:
         if not text:


### PR DESCRIPTION
## Summary

Three independent fixes found while running OpenKraken on Fedora (Bazzite / rpm-ostree) with a Kraken 2023 Elite:

1. **Portable LCD font resolution.** `backend/lcd_render.py` only looked for `DejaVuSans-Bold.ttf` under the Debian/Ubuntu path (`/usr/share/fonts/truetype/dejavu/`). On Fedora/Arch that file isn't there, and when DejaVu isn't installed at all PIL silently falls back to its low-res default bitmap font, so the LCD sensor screens render with poor typography.

2. **GUI crash on back-to-back errors.** `gui/main_window.py::_on_error` connects `statusBar.messageChanged` with `Qt.ConnectionType.UniqueConnection`. In PyQt6 (unlike C++ Qt, which silently no-ops) re-connecting an already-connected unique slot raises `TypeError: connection is not unique`. When errors arrive in quick succession (e.g. a cooling curve repeatedly failing to apply), the second `_on_error` call raised and crashed the GUI.

3. **Wrong / random sensor-frame orientation.** `backend/device.py::set_lcd_sensor_frame` pre-rotated each streamed frame with the liquidctl driver's `dev.orientation`. That attribute is only refreshed as a side effect of `set_screen()` and is left stale after an orientation change (it holds the value read *before* the write), and can be garbage on an HID reply de-sync. This rotated streamed sensor frames to the wrong / seemingly random direction and made orientation appear to change across restarts.

## Changes

- `lcd_render.py`: add Fedora/Arch candidate paths, and as a distro-agnostic fallback resolve a bold sans-serif via fontconfig (`fc-match`); cached, so the lookup runs at most once per process.
- `main_window.py`: guard the unique `connect()` with `try/except TypeError`, mirroring the existing disconnect guard in `_on_status_message_changed`.
- `device.py`: pre-rotate streamed frames with the app's own authoritative `lcd_orientation` (degrees → raw 0..3) instead of the driver's stale `dev.orientation`. This matches the value the user sets, the config persists, and the engine applies to the firmware at boot.

## Testing

- Fedora 44 (Bazzite), PyQt6 + Pillow, Python 3.14, Kraken 2023 Elite.
- Font: before, every `_font()` call logged `DejaVuSans-Bold not found` and screens used the bitmap fallback; after, `_font()` resolves to `NotoSans-Bold.ttf` via fontconfig, no warnings, all three styles render.
- Error handler: the crash reproduced reliably when a cooling curve failed to apply repeatedly; with the guard the status bar shows the error and the app stays up.
- Orientation: streamed sensor frames now follow the configured orientation and stay consistent across restarts.
- `python -m py_compile` clean on all three files.
